### PR TITLE
Don't die if no license is found

### DIFF
--- a/src/main/java/org/lineageos/generatebp/GenerateBp.kt
+++ b/src/main/java/org/lineageos/generatebp/GenerateBp.kt
@@ -72,13 +72,12 @@ internal class GenerateBp(
             // Get file path
             val dirPath = "${libsBase}/${it.module.aospModulePath}"
             val filePath = "${dirPath}/${it.file.name}"
-            val licensePath = "${filePath}.license"
 
             // Copy artifact to app/libs
             it.file.copyTo(File(filePath))
 
             // Write license file
-            File(licensePath).writeText(it.reuseCopyrightFileContent)
+            it.writeCopyrightFileForFile(filePath)
 
             // Extract AndroidManifest.xml for AARs
             if (it.file.extension == "aar") {
@@ -90,9 +89,7 @@ internal class GenerateBp(
                 }
 
                 // Write license file
-                File("${dirPath}/AndroidManifest.xml.license").writeText(
-                    it.reuseCopyrightFileContent
-                )
+                it.writeCopyrightFileForFile("${dirPath}/AndroidManifest.xml")
             }
 
             // Write Android.bp
@@ -250,6 +247,12 @@ internal class GenerateBp(
             "org.jetbrains.kotlinx:kotlinx-coroutines-reactive" -> "kotlinx_coroutines_reactive"
             "org.jetbrains.kotlinx:kotlinx-coroutines-rx2" -> "kotlinx_coroutines_rx2"
             else -> moduleName.replace(":", "_")
+        }
+
+        private fun Artifact.writeCopyrightFileForFile(file: String) {
+            reuseCopyrightFileContent.takeIf { it.isNotEmpty() }?.let {
+                File("$file.license").writeText(it)
+            }
         }
     }
 }

--- a/src/main/java/org/lineageos/generatebp/models/Artifact.kt
+++ b/src/main/java/org/lineageos/generatebp/models/Artifact.kt
@@ -86,21 +86,24 @@ data class Artifact(
     )
 
     val reuseCopyrightFileContent by lazy {
-        require(licenses.isNotEmpty()) {
-            "Licenses not found for module ${module.gradleName}"
-        }
-
         if (licenses.size > 1) {
             Logger.info(
                 "More than one license found for ${module.gradleName}, picking the first one found"
             )
         }
 
-        val license = licenses.first()
+        val license = licenses.firstOrNull() ?: run {
+            Logger.info("No license found for module ${module.gradleName}")
+            null
+        }
 
         val copyrights = organizationName?.let {
             listOf(it)
         } ?: developersNames
+
+        if (copyrights.isEmpty()) {
+            Logger.info("No copyright found for ${module.gradleName}")
+        }
 
         ReuseUtils.generateReuseCopyrightContent(license, copyrights, inceptionYear)
     }

--- a/src/main/java/org/lineageos/generatebp/utils/ReuseUtils.kt
+++ b/src/main/java/org/lineageos/generatebp/utils/ReuseUtils.kt
@@ -15,7 +15,7 @@ object ReuseUtils {
     private val currentYear = Year.now().value
 
     fun generateReuseCopyrightContent(
-        license: License,
+        license: License? = null,
         copyrights: List<String> = listOf(),
         initialYear: Int? = null,
         addNewlineBetweenCopyrightAndLicense: Boolean = true,
@@ -35,12 +35,17 @@ object ReuseUtils {
                     )
                 )
             }
-            if (addNewlineBetweenCopyrightAndLicense) {
+        }
+
+        license?.let {
+            if (addNewlineBetweenCopyrightAndLicense && copyrights.isNotEmpty()) {
                 append("\n")
             }
+
+            append(SPDX_LICENSE_IDENTIFIER_TEMPLATE.format(it.spdxId))
         }
-        append(SPDX_LICENSE_IDENTIFIER_TEMPLATE.format(license.spdxId))
-        if (addEndingNewline) {
+
+        if (addEndingNewline && isNotEmpty()) {
             append("\n")
         }
     }


### PR DESCRIPTION
* It isn't generateBp's job to make sure proper licenses are there, `reuse lint` does
* While at it, also warn if no copyright is found

Change-Id: I0ce276d0e1ec41d5323c9c28a72edf63bf5a961e