### PR TITLE
Use current year from Android.bp when running in CI environment

### DIFF
--- a/src/main/java/org/lineageos/generatebp/GenerateBp.kt
+++ b/src/main/java/org/lineageos/generatebp/GenerateBp.kt
@@ -18,7 +18,17 @@ internal class GenerateBp(
     private val project: Project,
     private val targetSdk: Int,
     private val isAvailableInAOSP: (module: Module) -> Boolean,
+    private val libsBase: File = File("${project.projectDir.absolutePath}/libs"),
 ) {
+    init {
+        // When running in CI, override current year with the one from the libs/Android.bp file
+        if (System.getenv("CI") == "true") {
+            ReuseUtils.readCurrentCopyrightYear("$libsBase/Android.bp")?.let {
+                ReuseUtils.currentYear = it
+            }
+        }
+    }
+
     private val configuration = project.configurations["releaseRuntimeClasspath"]
     private val resolvedConfiguration = configuration.resolvedConfiguration
 
@@ -37,7 +47,6 @@ internal class GenerateBp(
         Module.fromResolvedDependency(it, targetSdk)
     }.toSortedSet()
 
-    private val libsBase = File("${project.projectDir.absolutePath}/libs")
     private val libsAndroidBpHeader = buildString {
         append("//\n")
         append(

--- a/src/main/java/org/lineageos/generatebp/utils/ReuseUtils.kt
+++ b/src/main/java/org/lineageos/generatebp/utils/ReuseUtils.kt
@@ -13,7 +13,7 @@ object ReuseUtils {
     private const val SPDX_FILE_COPYRIGHT_TEXT_TEMPLATE = "SPDX-FileCopyrightText: %s %s\n"
     private const val SPDX_LICENSE_IDENTIFIER_TEMPLATE = "SPDX-License-Identifier: %s"
 
-    private val currentYear = Year.now().value
+    internal var currentYear = Year.now().value
 
     fun generateReuseCopyrightContent(
         license: License? = null,
@@ -57,6 +57,15 @@ object ReuseUtils {
         }?.let {
             // Extract initial year from copyright text
             Regex("\\d+").find(it)?.value?.toInt()
+        }
+    }.getOrNull()
+
+    fun readCurrentCopyrightYear(path: String) = runCatching {
+        File(path).readLines().firstOrNull {
+            it.contains("SPDX-FileCopyrightText:")
+        }?.let {
+            // Extract current year from copyright text
+            Regex("(?:\\d+-)?(\\d+)").find(it)?.groupValues?.last()?.toInt()
         }
     }.getOrNull()
 }


### PR DESCRIPTION
This is supposed to prevent us from failing CI builds when last **/libs regen was done last year.