### PR TITLE
Alias kotlin-stdlib-jre{7,8} to kotlin-stdlib-jdk{7,8}

### DIFF
--- a/src/main/java/org/lineageos/generatebp/GenerateBp.kt
+++ b/src/main/java/org/lineageos/generatebp/GenerateBp.kt
@@ -299,6 +299,8 @@ internal class GenerateBp(
             "org.jetbrains.kotlin:kotlin-stdlib" -> "kotlin-stdlib"
             "org.jetbrains.kotlin:kotlin-stdlib-jdk7" -> "kotlin-stdlib-jdk7"
             "org.jetbrains.kotlin:kotlin-stdlib-jdk8" -> "kotlin-stdlib-jdk8"
+            "org.jetbrains.kotlin:kotlin-stdlib-jre7" -> "kotlin-stdlib-jdk7"
+            "org.jetbrains.kotlin:kotlin-stdlib-jre8" -> "kotlin-stdlib-jdk8"
             "org.jetbrains.kotlinx:kotlinx-coroutines-android" -> "kotlinx-coroutines-android"
             "org.jetbrains.kotlinx:kotlinx-coroutines-core" -> "kotlinx-coroutines-core"
             "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm" -> "kotlinx-coroutines-core-jvm"


### PR DESCRIPTION
jre module is deprecated and per MVN repository has been
moved to the same version jdk counterpart
