### PR TITLE
Set libs min SDK to app min SDK

### DIFF
--- a/example/app/build.gradle.kts
+++ b/example/app/build.gradle.kts
@@ -76,6 +76,7 @@ dependencies {
 
 configure<GenerateBpPluginExtension> {
     targetSdk.set(android.defaultConfig.targetSdk!!)
+    minSdk.set(android.defaultConfig.minSdk!!)
     availableInAOSP.set { module: Module ->
         when {
             module.group.startsWith("androidx") -> {

--- a/example/app/libs/Android.bp
+++ b/example/app/libs/Android.bp
@@ -9,7 +9,7 @@ android_library_import {
     name: "Example_androidx.core_core-ktx-nodeps",
     aars: ["androidx/core/core-ktx/1.13.1/core-ktx-1.13.1.aar"],
     sdk_version: "34",
-    min_sdk_version: "14",
+    min_sdk_version: "26",
     apex_available: [
         "//apex_available:platform",
         "//apex_available:anyapex",
@@ -24,7 +24,7 @@ android_library_import {
 android_library {
     name: "Example_androidx.core_core-ktx",
     sdk_version: "34",
-    min_sdk_version: "14",
+    min_sdk_version: "26",
     apex_available: [
         "//apex_available:platform",
         "//apex_available:anyapex",
@@ -42,7 +42,7 @@ android_library_import {
     name: "Example_com.google.android.material_material-nodeps",
     aars: ["com/google/android/material/material/1.12.0/material-1.12.0.aar"],
     sdk_version: "34",
-    min_sdk_version: "14",
+    min_sdk_version: "26",
     apex_available: [
         "//apex_available:platform",
         "//apex_available:anyapex",
@@ -72,7 +72,7 @@ android_library_import {
 android_library {
     name: "Example_com.google.android.material_material",
     sdk_version: "34",
-    min_sdk_version: "14",
+    min_sdk_version: "26",
     apex_available: [
         "//apex_available:platform",
         "//apex_available:anyapex",
@@ -105,7 +105,7 @@ java_import {
     name: "Example_com.google.errorprone_error_prone_annotations-nodeps",
     jars: ["com/google/errorprone/error_prone_annotations/2.15.0/error_prone_annotations-2.15.0.jar"],
     sdk_version: "34",
-    min_sdk_version: "14",
+    min_sdk_version: "26",
     apex_available: [
         "//apex_available:platform",
         "//apex_available:anyapex",
@@ -115,7 +115,7 @@ java_import {
 java_library_static {
     name: "Example_com.google.errorprone_error_prone_annotations",
     sdk_version: "34",
-    min_sdk_version: "14",
+    min_sdk_version: "26",
     apex_available: [
         "//apex_available:platform",
         "//apex_available:anyapex",
@@ -129,7 +129,7 @@ java_import {
     name: "Example_com.google.guava_listenablefuture-nodeps",
     jars: ["com/google/guava/listenablefuture/1.0/listenablefuture-1.0.jar"],
     sdk_version: "34",
-    min_sdk_version: "14",
+    min_sdk_version: "26",
     apex_available: [
         "//apex_available:platform",
         "//apex_available:anyapex",
@@ -139,7 +139,7 @@ java_import {
 java_library_static {
     name: "Example_com.google.guava_listenablefuture",
     sdk_version: "34",
-    min_sdk_version: "14",
+    min_sdk_version: "26",
     apex_available: [
         "//apex_available:platform",
         "//apex_available:anyapex",
@@ -153,7 +153,7 @@ java_import {
     name: "Example_com.squareup.okhttp3_okhttp-nodeps",
     jars: ["com/squareup/okhttp3/okhttp/4.12.0/okhttp-4.12.0.jar"],
     sdk_version: "34",
-    min_sdk_version: "14",
+    min_sdk_version: "26",
     apex_available: [
         "//apex_available:platform",
         "//apex_available:anyapex",
@@ -163,7 +163,7 @@ java_import {
 java_library_static {
     name: "Example_com.squareup.okhttp3_okhttp",
     sdk_version: "34",
-    min_sdk_version: "14",
+    min_sdk_version: "26",
     apex_available: [
         "//apex_available:platform",
         "//apex_available:anyapex",
@@ -178,7 +178,7 @@ java_library_static {
 java_library_static {
     name: "Example_com.squareup.okio_okio",
     sdk_version: "34",
-    min_sdk_version: "14",
+    min_sdk_version: "26",
     apex_available: [
         "//apex_available:platform",
         "//apex_available:anyapex",
@@ -192,7 +192,7 @@ java_import {
     name: "Example_com.squareup.okio_okio-jvm-nodeps",
     jars: ["com/squareup/okio/okio-jvm/3.9.1/okio-jvm-3.9.1.jar"],
     sdk_version: "34",
-    min_sdk_version: "14",
+    min_sdk_version: "26",
     apex_available: [
         "//apex_available:platform",
         "//apex_available:anyapex",
@@ -202,7 +202,7 @@ java_import {
 java_library_static {
     name: "Example_com.squareup.okio_okio-jvm",
     sdk_version: "34",
-    min_sdk_version: "14",
+    min_sdk_version: "26",
     apex_available: [
         "//apex_available:platform",
         "//apex_available:anyapex",
@@ -216,7 +216,7 @@ java_library_static {
 java_library_static {
     name: "Example_io.coil-kt.coil3_coil",
     sdk_version: "34",
-    min_sdk_version: "14",
+    min_sdk_version: "26",
     apex_available: [
         "//apex_available:platform",
         "//apex_available:anyapex",
@@ -230,7 +230,7 @@ android_library_import {
     name: "Example_io.coil-kt.coil3_coil-android-nodeps",
     aars: ["io/coil-kt/coil3/coil-android/3.0.0-rc02/coil-release.aar"],
     sdk_version: "34",
-    min_sdk_version: "14",
+    min_sdk_version: "26",
     apex_available: [
         "//apex_available:platform",
         "//apex_available:anyapex",
@@ -244,7 +244,7 @@ android_library_import {
 android_library {
     name: "Example_io.coil-kt.coil3_coil-android",
     sdk_version: "34",
-    min_sdk_version: "14",
+    min_sdk_version: "26",
     apex_available: [
         "//apex_available:platform",
         "//apex_available:anyapex",
@@ -260,7 +260,7 @@ android_library {
 java_library_static {
     name: "Example_io.coil-kt.coil3_coil-core",
     sdk_version: "34",
-    min_sdk_version: "14",
+    min_sdk_version: "26",
     apex_available: [
         "//apex_available:platform",
         "//apex_available:anyapex",
@@ -274,7 +274,7 @@ android_library_import {
     name: "Example_io.coil-kt.coil3_coil-core-android-nodeps",
     aars: ["io/coil-kt/coil3/coil-core-android/3.0.0-rc02/coil-core-release.aar"],
     sdk_version: "34",
-    min_sdk_version: "14",
+    min_sdk_version: "26",
     apex_available: [
         "//apex_available:platform",
         "//apex_available:anyapex",
@@ -296,7 +296,7 @@ android_library_import {
 android_library {
     name: "Example_io.coil-kt.coil3_coil-core-android",
     sdk_version: "34",
-    min_sdk_version: "14",
+    min_sdk_version: "26",
     apex_available: [
         "//apex_available:platform",
         "//apex_available:anyapex",
@@ -320,7 +320,7 @@ android_library {
 java_library_static {
     name: "Example_io.coil-kt.coil3_coil-network-core",
     sdk_version: "34",
-    min_sdk_version: "14",
+    min_sdk_version: "26",
     apex_available: [
         "//apex_available:platform",
         "//apex_available:anyapex",
@@ -334,7 +334,7 @@ android_library_import {
     name: "Example_io.coil-kt.coil3_coil-network-core-android-nodeps",
     aars: ["io/coil-kt/coil3/coil-network-core-android/3.0.0-rc02/coil-network-core-release.aar"],
     sdk_version: "34",
-    min_sdk_version: "14",
+    min_sdk_version: "26",
     apex_available: [
         "//apex_available:platform",
         "//apex_available:anyapex",
@@ -349,7 +349,7 @@ android_library_import {
 android_library {
     name: "Example_io.coil-kt.coil3_coil-network-core-android",
     sdk_version: "34",
-    min_sdk_version: "14",
+    min_sdk_version: "26",
     apex_available: [
         "//apex_available:platform",
         "//apex_available:anyapex",
@@ -366,7 +366,7 @@ android_library {
 java_library_static {
     name: "Example_io.coil-kt.coil3_coil-network-okhttp",
     sdk_version: "34",
-    min_sdk_version: "14",
+    min_sdk_version: "26",
     apex_available: [
         "//apex_available:platform",
         "//apex_available:anyapex",
@@ -380,7 +380,7 @@ java_import {
     name: "Example_io.coil-kt.coil3_coil-network-okhttp-jvm-nodeps",
     jars: ["io/coil-kt/coil3/coil-network-okhttp-jvm/3.0.0-rc02/coil-network-okhttp-jvm-3.0.0-rc02.jar"],
     sdk_version: "34",
-    min_sdk_version: "14",
+    min_sdk_version: "26",
     apex_available: [
         "//apex_available:platform",
         "//apex_available:anyapex",
@@ -390,7 +390,7 @@ java_import {
 java_library_static {
     name: "Example_io.coil-kt.coil3_coil-network-okhttp-jvm",
     sdk_version: "34",
-    min_sdk_version: "14",
+    min_sdk_version: "26",
     apex_available: [
         "//apex_available:platform",
         "//apex_available:anyapex",

--- a/src/main/java/org/lineageos/generatebp/GenerateBpPlugin.kt
+++ b/src/main/java/org/lineageos/generatebp/GenerateBpPlugin.kt
@@ -15,7 +15,10 @@ class GenerateBpPlugin : Plugin<Project> {
         project.task("generateBp") {
             doLast {
                 GenerateBp(
-                    project, extension.targetSdk.get(), extension.availableInAOSP.get()
+                    project,
+                    extension.targetSdk.get(),
+                    extension.minSdk.get(),
+                    extension.availableInAOSP.get(),
                 )()
             }
         }

--- a/src/main/java/org/lineageos/generatebp/GenerateBpPluginExtension.kt
+++ b/src/main/java/org/lineageos/generatebp/GenerateBpPluginExtension.kt
@@ -10,5 +10,6 @@ import org.lineageos.generatebp.models.Module
 
 interface GenerateBpPluginExtension {
     val targetSdk: Property<Int>
+    val minSdk: Property<Int>
     val availableInAOSP: Property<(module: Module) -> Boolean>
 }

--- a/src/main/java/org/lineageos/generatebp/models/Artifact.kt
+++ b/src/main/java/org/lineageos/generatebp/models/Artifact.kt
@@ -40,7 +40,7 @@ data class Artifact(
     val developersNames: List<String>,
     val inceptionYear: Int?,
     val targetSdkVersion: Int,
-    val minSdkVersion: Int,
+    val minSdkVersion: Int?,
     val dependencies: List<Module>,
     val hasJNIs: Boolean,
 ) : Comparable<Artifact> {
@@ -119,8 +119,6 @@ data class Artifact(
     }
 
     companion object {
-        const val DEFAULT_MIN_SDK_VERSION = 14
-
         fun fromResolvedArtifact(it: ResolvedArtifact, defaultTargetSdkVersion: Int): Artifact {
             val module = Module.fromModuleVersionIdentifier(it.moduleVersion.id)
 
@@ -134,7 +132,7 @@ data class Artifact(
             val pom = POM.fromArtifact(file, module)
 
             var targetSdkVersion = defaultTargetSdkVersion
-            var minSdkVersion = DEFAULT_MIN_SDK_VERSION
+            var minSdkVersion: Int? = null
             var hasJNIs = false
 
             if (it.extension == "aar") {


### PR DESCRIPTION
In some cases the artifact min SDK is lower than the
min SDK of the componenets it depends on.

This is fine in gradle but in AOSP manifest_merger
doesn't handle this case properly and fails.
