### PR TITLE
Map jspecify, which is available since QPR2

### DIFF
--- a/src/main/java/org/lineageos/generatebp/GenerateBp.kt
+++ b/src/main/java/org/lineageos/generatebp/GenerateBp.kt
@@ -308,6 +308,7 @@ internal class GenerateBp(
             "org.jetbrains.kotlinx:kotlinx-coroutines-rx2" -> "kotlinx_coroutines_rx2"
             "org.jetbrains.kotlinx:kotlinx-serialization-core" -> "kotlinx_serialization_core"
             "org.jetbrains.kotlinx:kotlinx-serialization-json" -> "kotlinx_serialization_json"
+            "org.jspecify:jspecify" -> "jspecify"
             else -> moduleName.replace(":", "_")
         }
 


### PR DESCRIPTION
https://cs.android.com/android/platform/superproject/main/+/main:external/jspecify/Android.bp

It got introduced as vendored dep for Twelve, but it is actually buildable from source:
- https://review.lineageos.org/c/LineageOS/android_packages_apps_Twelve/+/422466