### PR TITLE
Map androidx.window:window-core-android

### DIFF
--- a/src/main/java/org/lineageos/generatebp/GenerateBp.kt
+++ b/src/main/java/org/lineageos/generatebp/GenerateBp.kt
@@ -275,6 +275,7 @@ internal class GenerateBp(
             "androidx.test.espresso:espresso-idling-resource" -> "androidx.test.espresso.idling-resource"
             "androidx.test.espresso:espresso-intents" -> "androidx.test.espresso.intents"
             "androidx.test.espresso:espresso-web" -> "androidx.test.espresso.web"
+            "androidx.window:window-core-android" -> "androidx.window_window-core"
             "com.adobe.xmp:xmpcore" -> "xmp_toolkit"
             "com.github.bumptech.glide:glide" -> "glide"
             "com.google.auto.value:auto-value-annotations" -> "auto_value_annotations"


### PR DESCRIPTION
It gets automatically mapped to "androidx.window_window-core-android" but AOSP ships it as "androidx.window_window-core"[1].

[1] - https://android.googlesource.com/platform/prebuilts/sdk/+/refs/tags/android-15.0.0_r23/current/androidx/m2repository/androidx/window/window-core-android/1.6.0-alpha01/Android.bp